### PR TITLE
Enabling 3rd party API URLs

### DIFF
--- a/src/com/parse4cn1/Parse.java
+++ b/src/com/parse4cn1/Parse.java
@@ -226,7 +226,7 @@ public class Parse {
      * <code>
      * public class StateMachine extends StateMachineBase {
      *   protected void initVars(Resources res) {
-     *     Parse.initialize(APP_ID, APP_REST_API_ID);
+     *     Parse.initialize(APP_ID, APP_REST_API_ID, MY_PARSE_API_URL);
      *   }
      * }
      * </code>

--- a/src/com/parse4cn1/Parse.java
+++ b/src/com/parse4cn1/Parse.java
@@ -245,7 +245,7 @@ public class Parse {
     static public void initialize(String applicationId, String clientKey, String parseAPIUrl) {
         mApplicationId = applicationId;
         mClientKey = clientKey;
-        mParseAPIUrl = parseApiUrl;
+        mParseAPIUrl = parseAPIUrl;
         
         ParseRegistry.registerDefaultSubClasses();
         ParseRegistry.registerExternalizableClasses();

--- a/src/com/parse4cn1/Parse.java
+++ b/src/com/parse4cn1/Parse.java
@@ -234,7 +234,7 @@ public class Parse {
      *
      * @param applicationId The application id provided in the Parse dashboard.
      * @param clientKey The client key provided in the Parse dashboard.
-     * @param parseApiUrl The base URL to use for Parse API calls.
+     * @param mParseAPIUrl The base URL to use for Parse API calls.
      * <p>
      * <b>Note:</b> Developers are advised to use the CLIENT KEY instead of
      * using the REST API in production code (cf.
@@ -242,10 +242,10 @@ public class Parse {
      * Hence, the latter is not exposed via this library. The same security
      * consideration explains why the MASTER KEY is not exposed either.
      */
-    static public void initialize(String applicationId, String clientKey, String parseApiUrl) {
+    static public void initialize(String applicationId, String clientKey, String parseAPIUrl) {
         mApplicationId = applicationId;
         mClientKey = clientKey;
-        mParseApiUrl = parseApiUrl;
+        mParseAPIUrl = parseApiUrl;
         
         ParseRegistry.registerDefaultSubClasses();
         ParseRegistry.registerExternalizableClasses();


### PR DESCRIPTION
This is my suggested solution to parse.com shutting down, discussed here: [http://stackoverflow.com/questions/36548284/what-will-happen-to-parse4cn1-when-they-shut-down-parse-com](url). 

Unfortunately, I'm unable to go through the testing procedure you recommend, but I think the changes are straightforward enough that they can be accepted. To be specific I have overloaded Parse.initialize() with a new parameter `String parseApiUrl`.