### PR TITLE
Fix ParseFile content-type , Serialize ParseUser.current , ..

### DIFF
--- a/src/com/parse4cn1/ParseUser.java
+++ b/src/com/parse4cn1/ParseUser.java
@@ -342,6 +342,7 @@ public class ParseUser extends ParseObject {
         
         Util.writeUTF(sessionToken, out);
         Util.writeUTF(password, out);
+        Util.writeObject(this.equals(current) ? true : false, out);
     }
 
     /**
@@ -358,6 +359,7 @@ public class ParseUser extends ParseObject {
         
         sessionToken = Util.readUTF(in);
         password = Util.readUTF(in);
+        current = ((boolean) Util.readObject(in)) ? this : null;
     }
 
     @Override

--- a/src/com/parse4cn1/command/ParseUploadCommand.java
+++ b/src/com/parse4cn1/command/ParseUploadCommand.java
@@ -54,6 +54,7 @@ public class ParseUploadCommand extends ParseCommand {
 
         if (contentType != null) {
             request.addRequestHeader(ParseConstants.HEADER_CONTENT_TYPE, contentType);
+            addHeader(ParseConstants.HEADER_CONTENT_TYPE, contentType);
         }
     }
 

--- a/src/com/parse4cn1/operation/IncrementFieldOperation.java
+++ b/src/com/parse4cn1/operation/IncrementFieldOperation.java
@@ -48,7 +48,6 @@ public class IncrementFieldOperation implements ParseOperation {
             throws ParseException {
 
         if (oldValue == null) {
-            needIncrement = false;
             return amount;
         }
 


### PR DESCRIPTION
Currently the content-type is always json so i added this line of code to overwrite the default content-type 

```
    setupDefaultHeaders(): add the headers to "headers" which is used in perform()[line:97] to add headers to the "request" which overwrite the content-type with the default content-type from "headers"
```

However, parse create the file in both cases :D 

---

Update: Serializing ParseUser.current to keep user loggedin offline, However i'm not serializing the object itself i just store a flag to know if this object is the 'current'.

---

Fix increment operation 

> needIncrement was set to false when oldValue is null which cause the amount only to be encoded each time
> Most likely needIncrement=false was meant to be wrote in the next if condition however i didnt but it there to keep the server data more atomic
