### PR TITLE
Adding user sessionToken to default header

### DIFF
--- a/src/com/parse4cn1/ParseQuery.java
+++ b/src/com/parse4cn1/ParseQuery.java
@@ -52,7 +52,6 @@ public class ParseQuery<T extends ParseObject> {
     private int skip;
     private String order;
     private boolean caseSensitive = true;
-    private String sessionToken = null;
 
     /**
      * Creates a ParseQuery for the specified class type.
@@ -841,9 +840,6 @@ public class ParseQuery<T extends ParseObject> {
         ParseGetCommand command = new ParseGetCommand(getEndPoint());
         query.remove(ParseConstants.FIELD_CLASSNAME);
         addDataToCommand(command, query);
-        if (sessionToken != null)
-            command.addHeader(ParseConstants.HEADER_SESSION_TOKEN, sessionToken);
-
         ParseResponse response = command.perform();
         List<T> results = new ArrayList<T>();
         if (!response.isFailed()) {
@@ -923,8 +919,6 @@ public class ParseQuery<T extends ParseObject> {
         }
         query.remove(ParseConstants.FIELD_CLASSNAME);
         addDataToCommand(command, query);
-        if (sessionToken != null)
-            command.addHeader(ParseConstants.HEADER_SESSION_TOKEN, sessionToken);
         ParseResponse response = command.perform();
         if (!response.isFailed()) {
             if (response.getJsonObject() == null) {
@@ -1114,19 +1108,4 @@ public class ParseQuery<T extends ParseObject> {
         }
     }
 
-    /**
-     * Add the current user sesseonToken to the request headers
-     */
-    public void addSessionToken() {
-        addSessionToken(ParseUser.getCurrent().getSessionToken());
-    }
-
-    /**
-     * Add sesseonToken to the request headers.
-     *
-     * @param sessionToken a session token.
-     */
-    public void addSessionToken(String sessionToken) {
-        this.sessionToken = sessionToken;
-    }
 }

--- a/src/com/parse4cn1/ParseQuery.java
+++ b/src/com/parse4cn1/ParseQuery.java
@@ -1107,5 +1107,4 @@ public class ParseQuery<T extends ParseObject> {
             return json;
         }
     }
-
 }

--- a/src/com/parse4cn1/command/ParseCommand.java
+++ b/src/com/parse4cn1/command/ParseCommand.java
@@ -189,7 +189,8 @@ public abstract class ParseCommand {
 
     /**
      * Adds the default headers (e.g., {@link ParseConstants#HEADER_APPLICATION_ID}
-     * and {@link ParseConstants#HEADER_CLIENT_KEY}) associated with Parse REST API calls.
+     * and {@link ParseConstants#HEADER_CLIENT_KEY}) associated with Parse REST API calls
+     * and (@Link ParseConstants#HEADER_SESSION_TOKEN) if there is a current user.
      * The content type is also set to {@link ParseConstants#CONTENT_TYPE_JSON} by default
      * and can be overruled in {@link #setUpRequest(com.codename1.io.ConnectionRequest)}.
      * @throws ParseException if anything goes wrong.

--- a/src/com/parse4cn1/command/ParseCommand.java
+++ b/src/com/parse4cn1/command/ParseCommand.java
@@ -203,6 +203,8 @@ public abstract class ParseCommand {
             // an explicit json content type in Parse.com now require it in the open source Parse server.
             // Hence, it is set here in the base command class by default.
             headers.put(ParseConstants.HEADER_CONTENT_TYPE, ParseConstants.CONTENT_TYPE_JSON);
+            if (ParseUser.getCurrent() != null && ParseUser.getCurrent().isAuthenticated())
+                headers.put(ParseConstants.HEADER_SESSION_TOKEN, ParseUser.getCurrent().getSessionToken());
         } catch (JSONException ex) {
             throw new ParseException(ParseException.INVALID_JSON, ParseException.ERR_PREPARING_REQUEST, ex);
         }


### PR DESCRIPTION
Greetings,

Adding session token to the header is required when using CLP on a _User
