### PR TITLE
ParseEncoder: add url for parse file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The Parse REST API is quite extensive. As such, we maintain an overview of the f
 | Installations | Implemented for Parse.com but pending for Parse Server | |
 | Cloud Code | IMPLEMENTED | |
 | GeoPoints | IMPLEMENTED | |
+| LiveQuery | [IMPLEMENTED](https://gist.github.com/ahmedengu/607266b5caeffbc19c4508b4684b4b7b) | |
+
 \*Advanced feature that cannot be realized using REST API only; involves native code integration. See the CN1 Parse push [guide](https://github.com/sidiabale/parse4cn1/wiki/Push-Notifications-Overview) for more details.
 
 | Advanced Features | Remarks |

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Parse Server is actively in development. As such, there are bugs/missing feature
 
 | Issue | Type | Implications |
 |:-------|:-------:|:-------	|
-|ParseCloud function calls requiring a session token fail|`parse4cn1` bug?|Session token header must be explicitly added to the post request as suggested [here](https://github.com/sidiabale/parse4cn1/issues/19#issuecomment-228212977). This issue will be fixed in `parse4cn1` a.s.a.p.|
 |Files and GeoPoints are not correctly saved in ParseConfig (see this [issue](https://github.com/ParsePlatform/parse-server/issues/2103))|Bug|Creating ParseConfig objects of type File or GeoPoint using the affected Parse Server versions will not work as expected. Also, the `parse4cn1` ParseConfigTest will fail when run against a backend in which the ParseConfig test objects were initialized using any of the affected Parse Server versions|
 | Master key is required for retrieving installations| Change w.r.t. Parse.com | Since `parse4cn1` does not support any operations requiring the master key, retrieving installations is now realized via cloud code (see this [comment](https://github.com/sidiabale/parse4cn1/issues/18#issuecomment-227690891)) |
 | Master key is required for sending push notifications from clients (see this [page](https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#client-push))| Change w.r.t. Parse.com | Since `parse4cn1` does not support any operations requiring the master key, client-triggered push notifications will have to be realized via cloud code|
+|Queries in ParseCloud functions that relate to a specific user must now include the user's session token. More info on this change is documented [here](https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#no-current-user)| Change w.r.t. Parse.com|Session token header must be explicitly added to the post request as illustrated [here](https://github.com/sidiabale/parse4cn1/issues/19#issuecomment-229250367).|
 
 ## Usage Examples ##
 See [Usage examples](https://github.com/sidiabale/parse4cn1/wiki/Usage-Examples)

--- a/src/com/parse4cn1/ParseObject.java
+++ b/src/com/parse4cn1/ParseObject.java
@@ -908,7 +908,7 @@ public class ParseObject implements IPersistable {
      */
     public <T extends ParseObject> T fetchIfNeeded() throws ParseException {
         if (!isDataAvailable() && !isDirty()) {
-            return fetch(getEndPoint(), getObjectId());
+            return fetch(getClassName(), getObjectId());
         } else {
             return (T) this;
         }

--- a/src/com/parse4cn1/command/ParseCommand.java
+++ b/src/com/parse4cn1/command/ParseCommand.java
@@ -189,7 +189,8 @@ public abstract class ParseCommand {
 
     /**
      * Adds the default headers (e.g., {@link ParseConstants#HEADER_APPLICATION_ID}
-     * and {@link ParseConstants#HEADER_CLIENT_KEY}) associated with Parse REST API calls.
+     * and {@link ParseConstants#HEADER_CLIENT_KEY}) associated with Parse REST API calls
+     * and (@Link ParseConstants#HEADER_SESSION_TOKEN) if there is a current user.
      * The content type is also set to {@link ParseConstants#CONTENT_TYPE_JSON} by default
      * and can be overruled in {@link #setUpRequest(com.codename1.io.ConnectionRequest)}.
      * @throws ParseException if anything goes wrong.
@@ -203,6 +204,8 @@ public abstract class ParseCommand {
             // an explicit json content type in Parse.com now require it in the open source Parse server.
             // Hence, it is set here in the base command class by default.
             headers.put(ParseConstants.HEADER_CONTENT_TYPE, ParseConstants.CONTENT_TYPE_JSON);
+            if (ParseUser.getCurrent() != null && ParseUser.getCurrent().isAuthenticated())
+                headers.put(ParseConstants.HEADER_SESSION_TOKEN, ParseUser.getCurrent().getSessionToken());
         } catch (JSONException ex) {
             throw new ParseException(ParseException.INVALID_JSON, ParseException.ERR_PREPARING_REQUEST, ex);
         }

--- a/src/com/parse4cn1/encode/ParseEncoder.java
+++ b/src/com/parse4cn1/encode/ParseEncoder.java
@@ -147,6 +147,7 @@ public class ParseEncoder {
             try {
                 output.put(ParseConstants.KEYWORD_TYPE, "File");
                 output.put("name", file.getName());
+                output.put("url", file.getUrl());
             } catch (JSONException ex) {
                 throw new ParseException(ParseException.INVALID_JSON, ParseException.ERR_PREPARING_REQUEST, ex);
             }

--- a/test/JavaTestApplication/src/com/parse4cn1/test/javaapplication/CN1TestJavaApplication.java
+++ b/test/JavaTestApplication/src/com/parse4cn1/test/javaapplication/CN1TestJavaApplication.java
@@ -115,7 +115,7 @@ public class CN1TestJavaApplication {
     
      private static int runTests() {
         int status = 0;
-        status += runTests("https://api.parse.com/1", "j1KMuH9otZlHcPncU9dZ1JFH7cXL8K5XUiQQ9ot8", "V6ZUyBtfERtzbq6vjeAb13tiFYij980HN9nQTWGB");
+        //status += runTests("https://api.parse.com/1", "j1KMuH9otZlHcPncU9dZ1JFH7cXL8K5XUiQQ9ot8", "V6ZUyBtfERtzbq6vjeAb13tiFYij980HN9nQTWGB");
         status += runTests("https://parse-parse4cn1.rhcloud.com/parse" /*openshift*/, "myAppId", null);
 //        status += runTests("https://parseapi.back4app.com", "OiTzm1ivZovdmMktQnqk8ajqBVIPgl4dlgUxw4dh", "fHquv9DA0SA5pd7VPO38tNzOrzrgTgfd7yY3nXbo");
         return status;


### PR DESCRIPTION
To match the [REST API](http://parseplatform.github.io/docs/rest/guide/#associating-with-objects) :
```
curl -X POST \
  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
  -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
  -H "Content-Type: application/json" \
  -d '{
        "name": "Andrew",
        "picture": {
          "name": "...profile.png",
          "url": "...profile.png",
          "__type": "File"
        }
      }' \
  https://api.parse.com/1/classes/PlayerProfile
```

Also it solve a current problem with having an array of files 

___
A temporary  [implementation ](https://gist.github.com/ahmedengu/607266b5caeffbc19c4508b4684b4b7b) for LiveQuery until the release of an official android implementation to follow ... however as it require websockets it's better to separate liveQury from parse4cn1