### PR TITLE
Fixed Java script port compile error

### DIFF
--- a/src/com/parse4cn1/ParseObject.java
+++ b/src/com/parse4cn1/ParseObject.java
@@ -21,7 +21,6 @@ package com.parse4cn1;
 import ca.weblite.codename1.json.JSONArray;
 import ca.weblite.codename1.json.JSONException;
 import ca.weblite.codename1.json.JSONObject;
-import com.codename1.io.Log;
 import com.codename1.io.Util;
 import com.parse4cn1.Parse.IPersistable;
 import com.parse4cn1.callback.GetCallback;
@@ -666,7 +665,6 @@ public class ParseObject implements IPersistable {
     public void save() throws ParseException {
 
         if (!isDirty()) {
-            //Log.p("ParseObject->save() !isDirty()="+!isDirty(), Log.DEBUG);
             Logger.getInstance().warn("Ignoring request to save unchanged/empty"
                     + " object");
             return;
@@ -676,7 +674,6 @@ public class ParseObject implements IPersistable {
 
         ParseCommand command;
         if (objectId == null) {
-            //Log.p("ParseObject->save() objectId == null"+!isDirty(), Log.DEBUG);
             command = new ParsePostCommand(getEndPoint());
         } else {
             command = new ParsePutCommand(getEndPoint(), getObjectId());

--- a/src/com/parse4cn1/ParseObject.java
+++ b/src/com/parse4cn1/ParseObject.java
@@ -21,6 +21,7 @@ package com.parse4cn1;
 import ca.weblite.codename1.json.JSONArray;
 import ca.weblite.codename1.json.JSONException;
 import ca.weblite.codename1.json.JSONObject;
+import com.codename1.io.Log;
 import com.codename1.io.Util;
 import com.parse4cn1.Parse.IPersistable;
 import com.parse4cn1.callback.GetCallback;
@@ -665,6 +666,7 @@ public class ParseObject implements IPersistable {
     public void save() throws ParseException {
 
         if (!isDirty()) {
+            //Log.p("ParseObject->save() !isDirty()="+!isDirty(), Log.DEBUG);
             Logger.getInstance().warn("Ignoring request to save unchanged/empty"
                     + " object");
             return;
@@ -674,6 +676,7 @@ public class ParseObject implements IPersistable {
 
         ParseCommand command;
         if (objectId == null) {
+            //Log.p("ParseObject->save() objectId == null"+!isDirty(), Log.DEBUG);
             command = new ParsePostCommand(getEndPoint());
         } else {
             command = new ParsePutCommand(getEndPoint(), getObjectId());

--- a/src/com/parse4cn1/encode/ParseEncoder.java
+++ b/src/com/parse4cn1/encode/ParseEncoder.java
@@ -170,8 +170,7 @@ public class ParseEncoder {
             return value;
         }
 
-        //LOGGER.error("Object type not decoded: " + value.getClass().getCanonicalName());
-        LOGGER.error("Object type not decoded: ");
+        LOGGER.error("Object type not decoded: " + value.getClass().getCanonicalName());
         throw new IllegalArgumentException("Invalid type for ParseObject: " + value.getClass().toString());
     }
 }

--- a/src/com/parse4cn1/encode/ParseEncoder.java
+++ b/src/com/parse4cn1/encode/ParseEncoder.java
@@ -170,7 +170,7 @@ public class ParseEncoder {
             return value;
         }
 
-        LOGGER.error("Object type not decoded: " + value.getClass().getCanonicalName());
+        LOGGER.error("Object type not decoded: " + value.getClass().toString());
         throw new IllegalArgumentException("Invalid type for ParseObject: " + value.getClass().toString());
     }
 }

--- a/src/com/parse4cn1/encode/ParseEncoder.java
+++ b/src/com/parse4cn1/encode/ParseEncoder.java
@@ -170,7 +170,8 @@ public class ParseEncoder {
             return value;
         }
 
-        LOGGER.error("Object type not decoded: " + value.getClass().getCanonicalName());
+        //LOGGER.error("Object type not decoded: " + value.getClass().getCanonicalName());
+        LOGGER.error("Object type not decoded: ");
         throw new IllegalArgumentException("Invalid type for ParseObject: " + value.getClass().toString());
     }
 }

--- a/src/com/parse4cn1/operation/IncrementFieldOperation.java
+++ b/src/com/parse4cn1/operation/IncrementFieldOperation.java
@@ -57,7 +57,8 @@ public class IncrementFieldOperation implements ParseOperation {
         }
 
         throw new IllegalArgumentException("You cannot increment a non-number."
-                + " Key type [" + oldValue.getClass().getCanonicalName() + "]");
+                + " Key type [" + oldValue.getClass().toString()+ "]");
+
     }
 
     @Override

--- a/src/com/parse4cn1/operation/IncrementFieldOperation.java
+++ b/src/com/parse4cn1/operation/IncrementFieldOperation.java
@@ -56,8 +56,10 @@ public class IncrementFieldOperation implements ParseOperation {
            return ParseOperationUtil.addNumbers(oldValue, this.amount); 
         }
 
+        /*throw new IllegalArgumentException("You cannot increment a non-number."
+                + " Key type [" + oldValue.getClass().getCanonicalName() + "]");*/
         throw new IllegalArgumentException("You cannot increment a non-number."
-                + " Key type [" + oldValue.getClass().getCanonicalName() + "]");
+                + " Key type []");
     }
 
     @Override

--- a/src/com/parse4cn1/operation/IncrementFieldOperation.java
+++ b/src/com/parse4cn1/operation/IncrementFieldOperation.java
@@ -56,10 +56,8 @@ public class IncrementFieldOperation implements ParseOperation {
            return ParseOperationUtil.addNumbers(oldValue, this.amount); 
         }
 
-        /*throw new IllegalArgumentException("You cannot increment a non-number."
-                + " Key type [" + oldValue.getClass().getCanonicalName() + "]");*/
         throw new IllegalArgumentException("You cannot increment a non-number."
-                + " Key type []");
+                + " Key type [" + oldValue.getClass().getCanonicalName() + "]");
     }
 
     @Override


### PR DESCRIPTION
Removed occurrences of getCanonicalName() method, reason being CN1 Java script port was not compiling. The method is not implemented on CN1 Java script port.