### PR TITLE
Logout(): Resting current/sessionToken before throwing exception

### DIFF
--- a/src/com/parse4cn1/ParseUser.java
+++ b/src/com/parse4cn1/ParseUser.java
@@ -320,11 +320,11 @@ public class ParseUser extends ParseObject {
             ParseCommand command = new ParsePostCommand(ENDPOINT_LOGOUT);
             command.addHeader(ParseConstants.HEADER_SESSION_TOKEN, getSessionToken());
             ParseResponse response = command.perform();
+            setSessionToken(null);
+            current = null;
             if (response.isFailed()) {
                 throw response.getException();
             }
-            setSessionToken(null);
-            current = null;
         }
     }
     


### PR DESCRIPTION
Greetings,

This prevent sending the old session token with following requests, Also resting the current user prevent unexpected behaviors thus the developer will always expect that the current user is null after calling logout().
This what happens with the js sdk, the user object saved in the local storage is deleted regardless of the response. 

Best Regards,
Ahmed